### PR TITLE
new Tags endpoints

### DIFF
--- a/guides/ReleaseNotes.md
+++ b/guides/ReleaseNotes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## New Endpoints: [Wix Blog API](wix-blog/)
+
+The [Tags](wix-blog/blog/tags/tag-object)
+endpoints are now available.
+
+(April 25, 2022)
 ## New Webhook: [Restaurants Orders API](wix-restaurants/orders)
 
 The new [New Order Webhook](wix-restaurants/orders/new-order-webhook)


### PR DESCRIPTION
[The Blog API](https://dev.wix.com/api/rest/wix-blog/blog) now has a [new Tags endpoint](https://dev.wix.com/api/rest/wix-blog/blog/tags/tag-object).
It allows third parties to retrieve and query the tags used to categorize Wix Blog posts.
The [Tag subdivision syntax is explained in the Intro](https://dev.wix.com/api/rest/wix-blog/blog/introduction).